### PR TITLE
Use ImageOS as cache key

### DIFF
--- a/install-requiredmodules/src/action.js
+++ b/install-requiredmodules/src/action.js
@@ -27,7 +27,7 @@ async function main() {
         const hash = String(execFileSync('pwsh', ['-noprofile', '-nologo', '-noninteractive', '-command', '$(Get-FileHash "' + requiredModules + '").Hash'])).trim()
         const psModulePath = String(execFileSync('pwsh', ['-noprofile', '-nologo', '-noninteractive', '-command', '$Env:PSModulePath.Split([IO.Path]::PathSeparator).Where({$_.StartsWith($Home)})'])).trim()
 
-        const os = (process.env['RUNNER_OS'] || process.env['OS'] || process.env['ImageOS'] || '')
+        const os = (process.env['ImageOS'] || process.env['RUNNER_OS'] || process.env['OS'] || '')
         var key = [os, 'psmodules', hash.trim()].join('-')
         core.info("Restore: '" + psModulePath + "' from cache: " + key)
         var cacheKey = await restore([psModulePath], key)


### PR DESCRIPTION
Changes the order of unique cache key generation to use `ImageOS` first so that matrix builds with e.g. multiple Linux versions do not break with below error message:

```
Unable to reserve cache with key Linux-psmodules-317DB88EFAFF4D1D0B5F92BF073201DA3F4083D92F59F60940FB05FABF623E14, another job may be creating this cache.
```

Reason:
- action currently generates a cache using "Linux" as the unique identifier
- this can sometimes lead to above error [as can be seen here](https://github.com/alt3/Docusaurus.Powershell/actions/runs/2389833954) (with two ubuntus using the same `Linux` cache key)
- using ImageOS should fix this as it would use e.g. `ubuntu16` and `ubuntu18`, [as explained here](https://github.com/actions/virtual-environments/issues/345)