### PR TITLE
Allow changing Powershell version for Pester tests

### DIFF
--- a/pester/ReadMe.md
+++ b/pester/ReadMe.md
@@ -9,8 +9,12 @@ Runs Invoke-Pester or Invoke-Gherkin depending on whether there are .tests.ps1 o
     - required: false
     - default: "*[Tt]est*"
 ### pesterVersion:
-    -  If you need a specific version of Pester (default is what's on your PSModulePath)
+    - If you need a specific version of Pester (default is what's on your PSModulePath)
     - required: false
+### shell:
+    - If you need a specific version of Powershell (default is `pwsh`)
+    - required: false
+    - default: "pwsh"
 ### includeTag:
     - If you want to only run some of your tests, a comma-separated list of tags
     - required: false

--- a/pester/action.yml
+++ b/pester/action.yml
@@ -7,6 +7,10 @@ inputs:
   pesterVersion:
     description: If you need a specific version of Pester. By default looks for RequiredModules.psd1 (or RequiredModules/RequiredModules.psd1)
     required: false
+  shell:
+    description: The PowerShell version your tests will run on.
+    required: false
+    default: "pwsh"
   testsDirectory:
     description: The path to the folder where your tests are. By default looks for *Tests* (e.g. PesterTests).
     required: false
@@ -38,4 +42,4 @@ runs:
   steps:
     - id: pester
       run: ${{ github.action_path }}/action.ps1 -PesterVersion '${{ inputs.pesterVersion }}' -ModuleUnderTest '${{ inputs.moduleUnderTest }}' -ModuleVersion '${{ inputs.moduleVersion }}' -TestsDirectory '${{ inputs.testsDirectory }}' -IncludeTag '${{ inputs.includeTag }}' -ExcludeTag '${{ inputs.excludeTag }}' -AdditionalModulePaths '${{ inputs.additionalModulePaths }}' -CodeCoveragePath '${{ inputs.codeCoveragePath }}'
-      shell: pwsh
+      shell: ${{ inputs.shell }}


### PR DESCRIPTION
Adds new input `inputs.shell` so we can test more Powershell versions.